### PR TITLE
Manipulação de pontos por controle remoto e ajustes

### DIFF
--- a/data/www/js/index.js
+++ b/data/www/js/index.js
@@ -75,16 +75,18 @@ document.querySelector("#add_team_a").addEventListener("click", (e) => {
 })
 
 document.querySelector("#add_team_b").addEventListener("click", (e) => {
-  updateScore('team_b_score', 1, false)
+  newScore = updateScore('team_b_score', 1, false)
+  post("/setscoreteamb", { "score": newScore })
 })
 
 document.querySelector("#sub_team_a").addEventListener("click", (e) => {
-  updateScore('team_a_score', -1, true)
+  newScore = updateScore('team_a_score', -1, true)
   post("/setscoreteama", { "score": newScore})
 })
 
 document.querySelector("#sub_team_b").addEventListener("click", (e) => {
-  updateScore('team_b_score', -1, false)
+  newScore = updateScore('team_b_score', -1, false)
+  post("/setscoreteamb", { "score": newScore })
 })
 
 function changeValue(tagId, newValue) {

--- a/include/header.h
+++ b/include/header.h
@@ -2,6 +2,7 @@
 #include "SystemClock.h"
 #include "FileSystem.h"
 #include "WifiPortal.h"
+#include "IRRemote.h"
 
 namespace BasicSettings
 {

--- a/lib/IRremote/IRRemote.cpp
+++ b/lib/IRremote/IRRemote.cpp
@@ -1,0 +1,51 @@
+#include "IRRemote.h"
+
+IRRemote irRemote;
+
+using namespace IRControls;
+
+bool IRRemote::begin()
+{
+    IRRemote::irrecv = new IRrecv(D4);
+    IRRemote::irrecv->enableIRIn();
+    return true;
+}
+
+void IRRemote::process()
+{
+    if (irrecv->decode(&results))
+    {
+        if (_debug) {
+            Serial.println(results.value, HEX);
+        }
+        
+        byte score;
+        switch (results.value)
+        {
+        case PLUS_A:            
+            if (_debug) { Serial.println("Chamou o PLUS_A"); }
+            score = ledDisplay.get_ScoreTeamA() + 1;
+            ledDisplay.set_ScoreTeamA(score);
+            break;
+        case SUB_A:
+            if (_debug) { Serial.println("Chamou o SUB_A"); }
+            score = ledDisplay.get_ScoreTeamA() - 1;
+            ledDisplay.set_ScoreTeamA(score);
+            break;
+        case PLUS_B:
+        if (_debug) { Serial.println("Chamou o PLUS_B"); }
+            score = ledDisplay.get_ScoreTeamB() + 1;
+            ledDisplay.set_ScoreTeamB(score);
+            break;
+        case SUB_B:
+        if (_debug) { Serial.println("Chamou o SUB_A"); }
+            score = ledDisplay.get_ScoreTeamB() - 1;
+            ledDisplay.set_ScoreTeamB(score);
+            break;
+        default:
+            break;
+        }
+
+        irrecv->resume();
+    }
+}

--- a/lib/IRremote/IRRemote.h
+++ b/lib/IRremote/IRRemote.h
@@ -1,0 +1,25 @@
+#include <IRremoteESP8266.h>
+#include <IRrecv.h>
+#include "LedDisplay.h"
+
+namespace IRControls
+{
+    static const uint32_t PLUS_A = 0x409F7A85;
+    static const uint32_t SUB_A = 0x409FFA05;
+    static const uint32_t PLUS_B = 0x409F728D;
+    static const uint32_t SUB_B = 0x409FF20D;
+}
+
+class IRRemote
+{
+private:
+    bool _debug = false;
+    IRrecv* irrecv;
+    decode_results results;
+public:
+    void set_debug(bool debug) { _debug = debug; }
+    bool begin();
+    void process();
+};
+
+extern IRRemote irRemote;

--- a/lib/LedDisplay/LedDisplay.cpp
+++ b/lib/LedDisplay/LedDisplay.cpp
@@ -53,17 +53,21 @@ void LedDisplay::setAllColors(CRGB ledColor)
 
 void LedDisplay::setSeparatedColors()
 {
-    byte score = get_ScoreTeamA() > 99 ? 99 : get_ScoreTeamA();    
+    byte score = get_ScoreTeamA();    
     byte firstDigit = get_FirstDigit(score);
     byte secondDigit = get_SecondDigit(score);
-    displayNumber(secondDigit, 0, _ledColorT1, false);
-    displayNumber(firstDigit, 1, _ledColorT1, true);
+    displayNumber(secondDigit, 6, _ledColorT1, false);
+    displayNumber(firstDigit, 7, _ledColorT1, true);
+    displayNumber(secondDigit, 2, _ledColorT1, false);
+    displayNumber(firstDigit, 3, _ledColorT1, true);
 
-    score = get_ScoreTeamB() > 99 ? 99 : get_ScoreTeamB();
+    score = get_ScoreTeamB();
     firstDigit = get_FirstDigit(score);
     secondDigit = get_SecondDigit(score);
-    displayNumber(secondDigit, 2, _ledColorT2, false);
-    displayNumber(firstDigit, 3, _ledColorT2, true);
+    displayNumber(secondDigit, 4, _ledColorT2, false);
+    displayNumber(firstDigit, 5, _ledColorT2, true);
+    displayNumber(secondDigit, 0, _ledColorT2, false);
+    displayNumber(firstDigit, 1, _ledColorT2, true);
     
     //displayNumber(get_Time(), 2, _ledColorTm);
     
@@ -157,7 +161,7 @@ void LedDisplay::updateLeds()
     yield();
 }
 
-void LedDisplay::displayNumber(byte number, byte segment, CRGB color, boolean isFirstDigit)
+void LedDisplay::displayNumber(byte number, byte segment, CRGB color, boolean blackIfZero)
 {
     /*
       __ __ __        __ __ __          __ __ __        __ __ __
@@ -183,7 +187,7 @@ void LedDisplay::displayNumber(byte number, byte segment, CRGB color, boolean is
     // top segment from left to right:    7, 6, 5, 4
     // bottom segment from left to right: 3, 2, 1, 0
 
-    color = isFirstDigit ? CRGB::Black : color;
+    color = blackIfZero && number == 0 ? CRGB::Black : color;
     byte startindex = segment < 2 ? (segment * 21) : (segment * 21) + 2;
 
     for (byte i = 0; i < 21; i++)
@@ -195,12 +199,12 @@ void LedDisplay::displayNumber(byte number, byte segment, CRGB color, boolean is
 
 void LedDisplay::set_ScoreTeamA(byte score)
 {
-    scoreTeamA = score;
+    scoreTeamA = score > 99 ? 99 : score;
 }
 
 void LedDisplay::set_ScoreTeamB(byte score)
 {
-    scoreTeamB = score;
+    scoreTeamB = score > 99 ? 99 : score;
 }
 
 byte LedDisplay::get_ScoreTeamA()

--- a/lib/LedDisplay/LedDisplay.cpp
+++ b/lib/LedDisplay/LedDisplay.cpp
@@ -52,9 +52,19 @@ void LedDisplay::setAllColors(CRGB ledColor)
 }
 
 void LedDisplay::setSeparatedColors()
-{    
-    displayNumber(get_ScoreTeamA(), 0, _ledColorT1);
-    //displayNumber(get_ScoreTeamB(), 1, _ledColorT2);
+{
+    byte score = get_ScoreTeamA() > 99 ? 99 : get_ScoreTeamA();    
+    byte firstDigit = get_FirstDigit(score);
+    byte secondDigit = get_SecondDigit(score);
+    displayNumber(secondDigit, 0, _ledColorT1, false);
+    displayNumber(firstDigit, 1, _ledColorT1, true);
+
+    score = get_ScoreTeamB() > 99 ? 99 : get_ScoreTeamB();
+    firstDigit = get_FirstDigit(score);
+    secondDigit = get_SecondDigit(score);
+    displayNumber(secondDigit, 2, _ledColorT2, false);
+    displayNumber(firstDigit, 3, _ledColorT2, true);
+    
     //displayNumber(get_Time(), 2, _ledColorTm);
     
     // for (int i = 0; i < 10; i++)
@@ -69,6 +79,16 @@ void LedDisplay::setSeparatedColors()
     // {
     //     leds[i] = _ledColorTm;
     // }
+}
+
+byte LedDisplay::get_FirstDigit(byte score) 
+{
+    return score / 10 % 10;
+}
+
+byte LedDisplay::get_SecondDigit(byte score)
+{
+    return score % 10;
 }
 
 void LedDisplay::set_LedColor(ValueRGB color, int id)
@@ -137,7 +157,7 @@ void LedDisplay::updateLeds()
     yield();
 }
 
-void LedDisplay::displayNumber(byte number, byte segment, CRGB color)
+void LedDisplay::displayNumber(byte number, byte segment, CRGB color, boolean isFirstDigit)
 {
     /*
       __ __ __        __ __ __          __ __ __        __ __ __
@@ -163,6 +183,7 @@ void LedDisplay::displayNumber(byte number, byte segment, CRGB color)
     // top segment from left to right:    7, 6, 5, 4
     // bottom segment from left to right: 3, 2, 1, 0
 
+    color = isFirstDigit ? CRGB::Black : color;
     byte startindex = segment < 2 ? (segment * 21) : (segment * 21) + 2;
 
     for (byte i = 0; i < 21; i++)

--- a/lib/LedDisplay/LedDisplay.h
+++ b/lib/LedDisplay/LedDisplay.h
@@ -22,7 +22,7 @@ namespace Digits
         0b111111000111000000111, // [4] 4
         0b111000111111000111111, // [5] 5
         0b111000111111111111111, // [6] 6
-        0b111111111000000000111, // [7] 7
+        0b000111111000000000111, // [7] 7
         0b111111111111111111111, // [8] 8
         0b111111111111000111111, // [9] 9
         0b000000000000000000000, // [10] off
@@ -52,6 +52,9 @@ private:
     byte scoreTeamA = 0;
     byte scoreTeamB = 0;
 
+    byte get_FirstDigit(byte score);
+    byte get_SecondDigit(byte score);
+
 public:
     void set_debug(bool debug) { _debug = debug; }
 
@@ -66,7 +69,7 @@ public:
 
     void updateLeds();
 
-    void displayNumber(byte number, byte segment, CRGB color);
+    void displayNumber(byte number, byte segment, CRGB color, boolean isFirstDigit);
 
     void set_ScoreTeamA(byte newScore);
     byte get_ScoreTeamA();

--- a/lib/WifiPortal/WifiPortal.cpp
+++ b/lib/WifiPortal/WifiPortal.cpp
@@ -97,6 +97,18 @@ void WifiPortal:: setScoreTeamA()
     server->send(200, "text/json", "{\"result\":\"ok\"}");
 }
 
+void WifiPortal:: setScoreTeamB()
+{
+    auto json = server->arg(1);    
+    size_t capacity = JSON_OBJECT_SIZE(1) + 40;
+    auto doc = fileSystem.jsonToDocument(json, capacity);
+
+    byte score = doc["score"];
+    ledDisplay.set_ScoreTeamB(score);
+    
+    server->send(200, "text/json", "{\"result\":\"ok\"}");
+}
+
 void WifiPortal::handleClock()
 {
     // DD/MM/YYYY hh:mm:ss
@@ -211,6 +223,7 @@ bool WifiPortal::begin()
     server->on(String(F("/setclock")).c_str(), HTTP_POST, std::bind(&WifiPortal::handleClock, this));
     server->on(String(F("/save")).c_str(), HTTP_GET, std::bind(&WifiPortal::handleSaveSettings, this));
     server->on(String(F("/setscoreteama")).c_str(), HTTP_POST, std::bind(&WifiPortal::setScoreTeamA, this));
+    server->on(String(F("/setscoreteamb")).c_str(), HTTP_POST, std::bind(&WifiPortal::setScoreTeamB, this));
 
     server->serveStatic("/", LittleFS, "/www/", "max-age=86400");
     server->serveStatic("/index.html", LittleFS, "/www/index.html", "max-age=86400");

--- a/lib/WifiPortal/WifiPortal.h
+++ b/lib/WifiPortal/WifiPortal.h
@@ -32,6 +32,7 @@ private:
     void handleClock();
     void handleNotFound();
     void setScoreTeamA();
+    void setScoreTeamB();
     // void handleRoot();
 
 public:

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,3 +20,4 @@ lib_deps =
 	paulstoffregen/DS1307RTC@0.0.0-alpha+sha.c2590c0033
 	bblanchon/ArduinoJson@^6.17.1
 	fastled/FastLED@^3.3.3
+	crankyoldgit/IRremoteESP8266@^2.8.6

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,18 +2,20 @@
 
 void setup()
 {
-  BasicSettings::setLibsDebugOption(true);
-  BasicSettings::SerialBegin();
-  if(!fileSystem.begin()){ return; };
-  if(!wifiPortal.begin()){ return; };
-  if(!ledDisplay.begin()){ return; };
-  BasicSettings::LoadSettings();
+    BasicSettings::setLibsDebugOption(true);
+    BasicSettings::SerialBegin();
+    if(!fileSystem.begin()){ return; };
+    if(!wifiPortal.begin()){ return; };
+    if(!ledDisplay.begin()){ return; };
+    if(!irRemote.begin()){ return; }
+    BasicSettings::LoadSettings();
 }
 
 void loop()
 {
-  wifiPortal.handleClient();
-  ledDisplay.updateLeds();
+    wifiPortal.handleClient();
+    ledDisplay.updateLeds();
+    irRemote.process();
 }
 
 namespace BasicSettings
@@ -25,6 +27,7 @@ namespace BasicSettings
         fileSystem.set_debug(_debug);
         wifiPortal.set_debug(_debug);
         ledDisplay.set_debug(_debug);
+        irRemote.set_debug(_debug);
     }
 
     void SerialBegin(unsigned long baudrate)


### PR DESCRIPTION
Foi implementada a manipulação do placar através de controle remoto.

Os dígitos hexadecimais cadastrados referem-se aos dígitos capturados a partir dos comandos disparados pelo controle remoto utilizado para testes e serão trocados futuramente pelos dígitos apropriados do controle remoto correto.

Para validar o circuito completo, os pontos do time A são registrados nos segmentos 6->7 e 2->3, bem como os pontos do time B são registrados nos segmentos 4->5 e 0->1.

O método `displayNumber` recebeu um parâmetro novo, com o intuito de apagar a cor do dígito à esquerda (nas dezenas), para que apareça apenas 1 ao invés de 01, por exemplo.

Obs: algumas mudanças listadas são origundas do merge com a branch "marcacao_dos_scores".